### PR TITLE
Fetch and render rockets from  SpaceX API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "react-redux": "^7.2.6",
         "react-router-dom": "^6.2.1",
         "react-scripts": "5.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.4.1",
         "web-vitals": "^2.1.4"
       }
     },
@@ -5857,6 +5859,11 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
+    },
+    "node_modules/deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
     },
     "node_modules/deep-equal": {
       "version": "1.1.1",
@@ -13318,6 +13325,14 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "dependencies": {
+        "deep-diff": "^0.3.5"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
@@ -20240,6 +20255,11 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
     },
+    "deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
+    },
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -25515,6 +25535,14 @@
       "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
       "requires": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "requires": {
+        "deep-diff": "^0.3.5"
       }
     },
     "redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "react-redux": "^7.2.6",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
+    "redux-logger": "^3.0.6",
+    "redux-thunk": "^2.4.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/css/RocketItem.css
+++ b/src/components/css/RocketItem.css
@@ -1,0 +1,45 @@
+.rocket-item {
+  display: flex;
+  margin: 20px;
+}
+
+.rocket-item__image img {
+  width: 300px;
+  height: 100%;
+}
+
+.rocket-item__name {
+  margin: 0;
+}
+
+.rocket-item__info {
+  font-size: 20px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 0 50px 30px 50px;
+  justify-content: flex-start;
+}
+
+.statuss { /* fix class name to show status */
+  font-size: 13px;
+  margin-bottom: 10px;
+  background-color: #007bff;
+  color: #fff;
+  padding: 0 5px;
+  margin-right: 10px;
+  border-radius: 5px;
+  border: 1px solid #007bff;
+}
+
+.rocket-item__reserve-btn {
+  height: 50px;
+  background-color: #007bff;
+  border-radius: 5px;
+  border: none;
+  color: #fff;
+  font-size: 20px;
+  font-weight: bold;
+  cursor: pointer;
+  border: 1px solid #007bff;
+}

--- a/src/components/rockets/RocketItem.js
+++ b/src/components/rockets/RocketItem.js
@@ -1,3 +1,4 @@
+import '../css/RocketItem.css';
 // create view for rocket item
 
 const RocketItem = ({ rocket }) => {
@@ -9,14 +10,16 @@ const RocketItem = ({ rocket }) => {
       </div>
       <div className="rocket-item__info">
         <h2 className="rocket-item__name">{rocket_name}</h2>
-        <p className="rocket-item__description">{description}</p>
+        <p className="rocket-item__description"><span className='status'>{reserved ? 'Reserved' : ''}</span>{description}</p>
+        <div>
         <button
           className="rocket-item__reserve-btn"
           disabled={reserved}
           onClick={() => console.log('reserve')}
         >
-          {reserved ? 'Reserved' : 'Reserve'}
+          {reserved ? 'Cancel Reservation' : 'Reserve Rocket'}
         </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/rockets/RocketItem.js
+++ b/src/components/rockets/RocketItem.js
@@ -1,14 +1,14 @@
 // create view for rocket item
 
 const RocketItem = ({ rocket }) => {
-  const { id, name, description, image, reserved } = rocket;
+  const { rocket_id, rocket_name, description, flickr_images, reserved } = rocket;
   return (
     <div className="rocket-item">
       <div className="rocket-item__image">
-        <img src={image} alt={name} />
+        <img src={flickr_images} alt={rocket_name} />
       </div>
       <div className="rocket-item__info">
-        <h2 className="rocket-item__name">{name}</h2>
+        <h2 className="rocket-item__name">{rocket_name}</h2>
         <p className="rocket-item__description">{description}</p>
         <button
           className="rocket-item__reserve-btn"

--- a/src/components/rockets/RocketsList.js
+++ b/src/components/rockets/RocketsList.js
@@ -8,7 +8,7 @@ const RocketsList = () => {
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch(fetchRockets());
-  },);
+  }, []);
 
   return rockets.map(rocket => (
     <RocketItem key={rocket.id} rocket={rocket} />

--- a/src/redux/store/configureStore.js
+++ b/src/redux/store/configureStore.js
@@ -1,6 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { combineReducers } from 'redux'
+import thunk from 'redux-thunk'
 import rockets from './rockets'
+import logger from 'redux-logger';
 
 const reducer = combineReducers({
   // reducers go here
@@ -10,6 +12,7 @@ const reducer = combineReducers({
 
 const store = configureStore({
   reducer,
+  middleware: [thunk, logger]
 })
 
 export default store;

--- a/src/redux/store/rockets.js
+++ b/src/redux/store/rockets.js
@@ -1,5 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import axios from 'axios';
+axios.defaults.baseURL = 'https://api.spacexdata.com/v3/';
 
 // slice
 const rocketsSlice = createSlice({


### PR DESCRIPTION
- Fetched data from the Rockets endpoint  (https://api.spacexdata.com/v3/rockets) when the application starts (as Rockets is the default view).

Once the data are fetched, an action is dispatched to store the selected data in Redux store:

1. id

2. name

3. type
4. flickr_images

NOTE: Made sure to only dispatch those actions once and not add data to store on every re-render (i.e. when changing views / using navigation).


- Used `useSelector()` Redux Hook to select the state slices and render lists of rockets in corresponding routes. i.e.:
```javascript
// get rockets data from the store
const rockets = useSelector(state => state.rockets);
```

-  Styled the whole application "by hand"
- Rendered a list of rockets (as per design). For the image of a rocket using the first image in the array of `flickr_images`.
